### PR TITLE
upgrade kotlin to 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.61'
-    ext.kotlin_coroutines = '0.25.3'
+    ext.kotlin_version = '1.3.20'
+    ext.kotlin_coroutines = '1.1.1'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 01 14:51:15 EDT 2017
+#Mon Feb 18 10:48:58 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/snail-kotlin/src/main/java/com/compass/snail/Fail.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Fail.kt
@@ -2,7 +2,7 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 open class Fail<T>(private val _error: Throwable) : Observable<T>() {
     override fun subscribe(dispatcher: CoroutineDispatcher?, next: ((T) -> Unit)?, error: ((Throwable) -> Unit)?, done: (() -> Unit)?) {

--- a/snail-kotlin/src/main/java/com/compass/snail/IObservable.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/IObservable.kt
@@ -2,7 +2,7 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 interface IObservable<T> {
     fun subscribe(dispatcher: CoroutineDispatcher? = null, next: ((T) -> Unit)? = null, error: ((Throwable) -> Unit)? = null, done: (() -> Unit)? = null)

--- a/snail-kotlin/src/main/java/com/compass/snail/Just.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Just.kt
@@ -2,7 +2,7 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 open class Just<T>(private val value: T) : Observable<T>() {
     override fun subscribe(dispatcher: CoroutineDispatcher?, next: ((T) -> Unit)?, error: ((Throwable) -> Unit)?, done: (() -> Unit)?) {

--- a/snail-kotlin/src/main/java/com/compass/snail/Observable.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Observable.kt
@@ -3,8 +3,9 @@
 package com.compass.snail
 
 import android.util.Log
-import kotlinx.coroutines.experimental.CoroutineDispatcher
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 import java.util.concurrent.Semaphore
 
 open class Observable<T> : IObservable<T> {
@@ -70,7 +71,7 @@ open class Observable<T> : IObservable<T> {
 
     fun notify(subscriber: Subscriber<T>, event: Event<T>) {
         subscriber.dispatcher?.let {
-            launch(it) {
+            GlobalScope.launch(it) {
                 safeNotify(subscriber, event)
             }
             return

--- a/snail-kotlin/src/main/java/com/compass/snail/Replay.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Replay.kt
@@ -2,7 +2,7 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 open class Replay<T>(private val threshold: Int) : Observable<T>() {
     private var values: MutableList<T> = mutableListOf()

--- a/snail-kotlin/src/main/java/com/compass/snail/Subscriber.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Subscriber.kt
@@ -2,6 +2,6 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 data class Subscriber<in T>(val dispatcher: CoroutineDispatcher?, val eventHandler: (Event<T>) -> Unit)

--- a/snail-kotlin/src/test/java/com/compass/snail/ObservableTests.kt
+++ b/snail-kotlin/src/test/java/com/compass/snail/ObservableTests.kt
@@ -2,11 +2,12 @@
 
 package com.compass.snail
 
-import kotlinx.coroutines.experimental.CommonPool
-import kotlinx.coroutines.experimental.async
-import kotlinx.coroutines.experimental.delay
-import kotlinx.coroutines.experimental.newSingleThreadContext
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.newFixedThreadPoolContext
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -108,11 +109,11 @@ class ObservableTests {
 
     @Test
     fun testSubscribeOnRequestedDispatcher() {
-        var future = CompletableFuture<Boolean>()
+        val future = CompletableFuture<Boolean>()
 
-        async {
-            subject?.subscribe(dispatcher = CommonPool, next = {
-                future.complete(Thread.currentThread().name.toLowerCase().contains("commonpool"))
+        GlobalScope.async {
+            subject?.subscribe(dispatcher = Dispatchers.Default, next = {
+                future.complete(Thread.currentThread().name.toLowerCase().contains("default"))
             })
             subject?.next("1")
         }
@@ -122,10 +123,10 @@ class ObservableTests {
 
     @Test
     fun testOnDispatcher() {
-        var future = CompletableFuture<Boolean>()
+        val future = CompletableFuture<Boolean>()
 
         val threadName = "testThread"
-        val dispatcher = newSingleThreadContext(threadName)
+        val dispatcher = newFixedThreadPoolContext(1, threadName)
         val observable = Observable<Boolean>()
         observable.on(dispatcher).subscribe(next = {
             future.complete(Thread.currentThread().name.contains(threadName))
@@ -167,12 +168,12 @@ class ObservableTests {
     @Test
     fun testThrottle() {
         val observable = Observable<String>()
-        var received = mutableListOf<String>()
+        val received = mutableListOf<String>()
 
-        var future = CompletableFuture<Boolean>()
+        val future = CompletableFuture<Boolean>()
         val delayMs = 100L
 
-        async {
+        GlobalScope.async {
             delay(delayMs)
             future.complete(true)
         }


### PR DESCRIPTION
Upgrade Build Tool
https://stackoverflow.com/questions/44644524/kotlin-version-that-is-used-for-building-with-gradle-1-1-2-5-differs-from-the

Warning in gradle - no fix
https://stackoverflow.com/questions/52470044/warning-api-variant-getjavacompile-is-obsolete-and-has-been-replaced-with

Removing Common Pool
https://github.com/Kotlin/kotlinx.coroutines/issues/351

newSingleThread Deprecation
https://github.com/Kotlin/kotlinx.coroutines/issues/261