### PR TITLE
Upgrade Gradle version to 3.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'


### PR DESCRIPTION
### Summary
Upgrading Gradle version to `3.4.2`. The current version in Snail-Kotlin is `3.4.0`, but the latest version is released version `3.4.2`.