### PR TITLE
Fix for Kotlin Reflection Exception in Observable

### DIFF
--- a/snail-kotlin/src/main/java/com/compass/snail/Observable.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Observable.kt
@@ -2,7 +2,6 @@
 
 package com.compass.snail
 
-import android.util.Log
 import com.compass.snail.disposer.Disposable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.GlobalScope
@@ -93,7 +92,6 @@ open class Observable<T> : IObservable<T> {
             subscriber.eventHandler(event)
         } catch (e: Exception) {
             e.printStackTrace()
-            Log.e("Snail Observable", "Removing subscriber $subscriber")
             subscribers.remove(subscriber)
         }
     }

--- a/snail-kotlin/src/test/java/com/compass/snail/LifecycleTests.kt
+++ b/snail-kotlin/src/test/java/com/compass/snail/LifecycleTests.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LifecycleRegistry
 import com.compass.snail.disposer.disposeBy
 import com.compass.snail.disposer.onDestroy
 import com.compass.snail.disposer.onPause
-import com.compass.snail.disposer.onStart
 import com.compass.snail.disposer.onStop
 import org.junit.Assert
 import org.junit.Before


### PR DESCRIPTION
### Summary
- Fixes crashing bug due to a Kotlin reflection issue in `Observable.kt` by removing an Android `Log.e(...)` call, which shouldn't have been in the library to begin with.
- Removes an unused import in `LifecycleTests.kt`.

### Root Cause
- The Android `Log.e(...)` statement called the `Subscriber<E>`'s `.toString()` method, which tried to parse the anonymous lambdas as Strings.

### Solution
- Remove that call.
- I would add a unit test for this, but since the `Log.e(...)` call is getting removed, it doesn't make sense to test that.
- I'll add the steps to reproduce the error below though.

### How to Reproduce
- Add the Kotlin reflection artifact and add this test. The stacktrace below will be reproduced.
```
class ReflectionErrorTest {
    @Test 
    fun `expect an KotlinReflectionInternalError exception`() {
        var x = 0

        fun countUp() {
            x++
        }

        println(::countUp.parameters)
    }
}

// build.gradle
dependencies {
    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
}
```

### Stacktrace
```
kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Introspecting local functions, lambdas, anonymous functions and local variables is not yet fully supported in Kotlin reflection

	at kotlin.reflect.jvm.internal.EmptyContainerForLocal.fail(EmptyContainerForLocal.kt:41)
	at kotlin.reflect.jvm.internal.EmptyContainerForLocal.getFunctions(EmptyContainerForLocal.kt:37)
	at kotlin.reflect.jvm.internal.KDeclarationContainerImpl.findFunctionDescriptor(KDeclarationContainerImpl.kt:150)
	at kotlin.reflect.jvm.internal.KFunctionImpl$descriptor$2.invoke(KFunctionImpl.kt:56)
	at kotlin.reflect.jvm.internal.KFunctionImpl$descriptor$2.invoke(KFunctionImpl.kt:36)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:92)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:31)
	at kotlin.reflect.jvm.internal.KFunctionImpl.getDescriptor(KFunctionImpl.kt)
	at kotlin.reflect.jvm.internal.KFunctionImpl.getDescriptor(KFunctionImpl.kt:36)
	at kotlin.reflect.jvm.internal.KCallableImpl$_parameters$1.invoke(KCallableImpl.kt:39)
	at kotlin.reflect.jvm.internal.KCallableImpl$_parameters$1.invoke(KCallableImpl.kt:21)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:92)
	at kotlin.reflect.jvm.internal.KCallableImpl.getParameters(KCallableImpl.kt:71)
	at kotlin.jvm.internal.CallableReference.getParameters(CallableReference.java:117)
	at com.compass.snail.ExceptionTests.testSafeNotifyCrash(ExceptionTests.kt:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```