### PR TITLE
Fix concurrency bug in Replay

### DIFF
--- a/snail-kotlin/src/main/java/com/compass/snail/Replay.kt
+++ b/snail-kotlin/src/main/java/com/compass/snail/Replay.kt
@@ -4,9 +4,12 @@ package com.compass.snail
 
 import com.compass.snail.disposer.Disposable
 import kotlinx.coroutines.CoroutineDispatcher
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 open class Replay<T>(private val threshold: Int) : Observable<T>() {
     private var values: MutableList<T> = mutableListOf()
+    private val lock = ReentrantLock()
 
     override fun subscribe(dispatcher: CoroutineDispatcher?, next: ((T) -> Unit)?, error: ((Throwable) -> Unit)?, done: (() -> Unit)?): Disposable {
         replay(dispatcher, createHandler(next, error, done))
@@ -14,12 +17,16 @@ open class Replay<T>(private val threshold: Int) : Observable<T>() {
     }
 
     override fun next(value: T) {
-        values.add(value)
-        values = values.takeLast(threshold).toMutableList()
+        lock.withLock {
+            values.add(value)
+            values = values.takeLast(threshold).toMutableList()
+        }
         super.next(value)
     }
 
     private fun replay(dispatcher: CoroutineDispatcher?, handler: (Event<T>) -> Unit) {
-        values.forEach { notify(Subscriber(dispatcher, handler, this), Event(next = Next(it))) }
+        lock.withLock {
+            values.forEach { notify(Subscriber(dispatcher, handler, this), Event(next = Next(it))) }
+        }
     }
 }

--- a/snail-kotlin/src/test/java/com/compass/snail/ReplayTests.kt
+++ b/snail-kotlin/src/test/java/com/compass/snail/ReplayTests.kt
@@ -45,31 +45,34 @@ class ReplayTests {
     @Test
     fun testMultiThreadedBehavior() {
         val subject = Replay<Int>(1)
-
         var a = 0
         var b = 0
+
         subject.subscribe(next = {
-            a += it
+            a = it
         })
         subject.subscribe(next = {
-            b += it
+            b = it
         })
 
         val latch = CountDownLatch(2)
         thread {
-            while (a < 100) {
-                subject.next(1)
+            for (i in 1..100) {
+                subject.next(i)
             }
             latch.countDown()
         }
         thread {
-            while (b < 100) {
-                subject.next(1)
+            for (i in 1..100) {
+                subject.next(i)
             }
             latch.countDown()
         }
-        latch.await(2000, TimeUnit.SECONDS)
+        latch.await(1000, TimeUnit.SECONDS)
 
         subject.removeSubscribers()
+
+        assertEquals(100, a)
+        assertEquals(100, b)
     }
 }

--- a/snail-kotlin/src/test/java/com/compass/snail/ReplayTests.kt
+++ b/snail-kotlin/src/test/java/com/compass/snail/ReplayTests.kt
@@ -5,6 +5,9 @@ package com.compass.snail
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 
 class ReplayTests {
     private var subject: Replay<String>? = null
@@ -37,5 +40,36 @@ class ReplayTests {
         assertEquals("1", a[0])
         assertEquals("2", b[0])
         assertEquals(2, b.size)
+    }
+
+    @Test
+    fun testMultiThreadedBehavior() {
+        val subject = Replay<Int>(1)
+
+        var a = 0
+        var b = 0
+        subject.subscribe(next = {
+            a += it
+        })
+        subject.subscribe(next = {
+            b += it
+        })
+
+        val latch = CountDownLatch(2)
+        thread {
+            while (a < 100) {
+                subject.next(1)
+            }
+            latch.countDown()
+        }
+        thread {
+            while (b < 100) {
+                subject.next(1)
+            }
+            latch.countDown()
+        }
+        latch.await(2000, TimeUnit.SECONDS)
+
+        subject.removeSubscribers()
     }
 }


### PR DESCRIPTION
### JIRA
https://compass-tech.atlassian.net/browse/CEI-504

### Summary
- `Replay` has a concurrency bug. When multiple subscribers are posting values to it from different threads, we can hit an index out of bounds exception.
- This is causing a semi-major bug in the offline banner feature on Android.
- Adds a test (that breaks without the changes) and fixes `Replay` by adding concurrency locks around the internal values list.

### Stacktrace
```
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=2; index=2
       at java.util.ArrayList.add(ArrayList.java:468)
       at com.compass.snail.Replay.next(Replay.kt:17)
       at com.compass.snail.Variable.setValue(Variable.kt:18)
       at com.compass.compasslibrary.services.NetworkBroadcastReceiverService.updateConnection(NetworkBroadcastReceiverService.kt:42)
       at com.compass.compasslibrary.apiv3.ModelRequest$request$1$2.onFailure(ModelRequest.kt:59)
       at com.google.firebase.perf.network.zzf.onFailure(com.google.firebase:firebase-perf@@18.0.1:18)
       at okhttp3.RealCall$AsyncCall.execute(RealCall.java:161)
       at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
```
